### PR TITLE
Removed Missions No Longer Using extDB2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ Arma3 Database + Rcon Extension for both Windows + Linux.
 
 #### Public Missions / Mods using extDB2
 https://www.exilemod.com  
-http://a3wasteland.com  
-https://github.com/MrEliasen/Supremacy-Framework  
-https://armarpglife.com/forums  
 
 #### Features
 


### PR DESCRIPTION
Altis Life RPG for _Arma 3_ uses [extDB3](https://bitbucket.org/torndeco/extdb3/overview) since version 5.0.0. [armarpglife.com](https://armarpglife.com/forums) no longer available. Altis Life RPG repository available at [AsYetUntitled/Framework](https://github.com/AsYetUntitled/Framework). 

[MrEliasen/Supremacy-Framework](https://github.com/MrEliasen/Supremacy-Framework) uses extDB3 since 0.5.2 (20-08-2016). 

[A3Wasteland](A3Wasteland)/ArmA3_Wasteland._[map]_ uses extDB3 since v1.3c. 
